### PR TITLE
Replace `value` to object from result of AJAX query 

### DIFF
--- a/resources/js/components/FormField.vue
+++ b/resources/js/components/FormField.vue
@@ -145,6 +145,7 @@ export default {
 					}
 					if (this.value == option.value) {
 						this.selectedOptions.push(option);
+						this.value = option;
 					}
 				})
 			});


### PR DESCRIPTION
When the initial value is loaded it does not replace `value` with the result of the AJAX query (on initial load) when the matching object (i.e. `{value: 1, label: "xyz"}`).

This allows the value to present the label, instead of the raw value.
![Screenshot 2022-06-17 at 13 32 19](https://user-images.githubusercontent.com/5942607/174219467-c11f2b96-5df4-4bed-ac0d-c590335e96e3.png)
to:
![Screenshot 2022-06-17 at 13 32 24](https://user-images.githubusercontent.com/5942607/174219450-f2b4f365-9800-4bb2-a568-492c39b5d49f.png)
 
I may have overlooked if/how this is possible already ?